### PR TITLE
Fix: Clicking on "Home button" when in "tabs" page leads to a blank home page.

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,7 +2,8 @@ import { NgModule } from '@angular/core';
 import { PreloadAllModules, RouterModule, Routes } from '@angular/router';
 
 const routes: Routes = [
-  { path: '', redirectTo: 'tabs', pathMatch: 'full' },
+  { path: '', redirectTo: 'tabs/home', pathMatch: 'full' },
+  { path: 'tabs', redirectTo: 'tabs/home', pathMatch: 'full' },
   {
     path: 'login',
     loadChildren: () => import('./login/login.module').then( m => m.LoginPageModule)
@@ -16,7 +17,7 @@ const routes: Routes = [
     loadChildren: () => import('./tabs/tabs.module').then( m => m.TabsPageModule)
   },
   {
-    path: 'details/:id', //'details/:index'
+    path: 'details/:id',
     loadChildren: () => import('./details/details.module').then( m => m.DetailsPageModule)
   },
 


### PR DESCRIPTION
Fix: Clicking on "Home button" when in "tabs" page leads to a blank home page.

Now 'tabs' page is redirected to 'tabs/home' instead.